### PR TITLE
Add netlify identity widget

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -4,9 +4,21 @@
 		<meta charset="utf-8" />
 		<link rel="icon" href="/favicon.png" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
 		%svelte.head%
 	</head>
 	<body>
 		<div id="svelte">%svelte.body%</div>
+		<script>
+		  if (window.netlifyIdentity) {
+		    window.netlifyIdentity.on("init", user => {
+		      if (!user) {
+			window.netlifyIdentity.on("login", () => {
+			  document.location.href = "/admin/";
+			});
+		      }
+		    });
+		  }
+		</script>
 	</body>
 </html>


### PR DESCRIPTION
This fixes #4 but could be optimized. For instance, only loading this on the homepage would be best. This serves and a quick and dirty fix.