### PR TITLE
fix metadata is not defined

### DIFF
--- a/src/layouts/default.svelte
+++ b/src/layouts/default.svelte
@@ -1,21 +1,23 @@
-<script>  
-  // import {routes} from '../metadata'
-  
-  export let title
+<script>
+	import { getRoutes } from "../metadata";
+
+	const routes = getRoutes();
+
+	export let title;
 </script>
 
 <svelte:head>
-  <title>{title}</title>
+	<title>{title}</title>
 </svelte:head>
 
 <nav>
-  <ul>
-    <!-- {#each routes as route}
-      <li>
-        <a href={route.path}>{route.label}</a>
-      </li>
-    {/each} -->
-  </ul>
+	<ul>
+		{#each routes as route}
+			<li>
+				<a href={route.path}>{route.title}</a>
+			</li>
+		{/each}
+	</ul>
 </nav>
 
 <slot />


### PR DESCRIPTION
```
500
metadata is not defined
ReferenceError: metadata is not defined
    at /src/metadata.js:10:23
```

changing `{route.label}` to `{route.title}` because the current configuration doesn't create a `label` on .md files